### PR TITLE
Fix: Correct import paths for JSON data in CocktailListItem

### DIFF
--- a/src/components/CocktailListItem.jsx
+++ b/src/components/CocktailListItem.jsx
@@ -4,8 +4,8 @@ import { Link } from 'react-router-dom';
 // import PlaceholderImage from '../assets/cocktails/placeholder.png'; // Removed
 import { getImageUrl } from '../utils/cocktailImageLoader.js'; // Corrected path
 import { useFavorites } from '../hooks/useFavorites'; // Import useFavorites
-import bar1StockData from '../../data/bar1_stock.json'; // Added
-import bar2StockData from '../../data/bar2_stock.json'; // Added
+import bar1StockData from '../data/bar1_stock.json'; // Added
+import bar2StockData from '../data/bar2_stock.json'; // Added
 
 // Styled components (ensure they exist or are defined if not already)
 const ListItemWrapper = styled.div`


### PR DESCRIPTION
The import paths for `bar1_stock.json` and `bar2_stock.json` in `src/components/CocktailListItem.jsx` were pointing to an incorrect location (`../../data/`).

This commit updates the paths to `../data/` to correctly point to the `src/data/` directory, resolving the "Failed to resolve import" errors during local app loading.